### PR TITLE
Double quote to prevent globbing and word splitting

### DIFF
--- a/manuel-contrib-concurrent.manuel
+++ b/manuel-contrib-concurrent.manuel
@@ -9,7 +9,7 @@ function manuel_concurrent {
   if [[ ${#tasks[@]} == 0 ]]; then
     echo ">> Warning: manuel_concurrent called with no tasks array"
   fi
-  for t in ${tasks[@]}
+  for t in "${tasks[@]}"
   do
     echo ">> Starting $t"
     $t &


### PR DESCRIPTION
ShellCheck Sc2086

https://github.com/koalaman/shellcheck/wiki/Sc2086

Quoting prevents word splitting and glob expansion, and prevents the script
from breaking when input contains spaces, line feeds, glob characters
and such.
